### PR TITLE
fix: hardware requirements for various assembly steps

### DIFF
--- a/docs/wire-tool-v1.0/user-manual/index.md
+++ b/docs/wire-tool-v1.0/user-manual/index.md
@@ -342,7 +342,6 @@ Requires:
 - Tool Mount Print
 - M4x16 Countersunk Screw (3x)
 - Wago 221-412 (4x)
-- Wago 221-413
 
 ![Tool_Mount_Assm](images/ASSM_Tool_Mount_1.png)
 ![Tool_Mount_Assm](images/ASSM_Tool_Mount_2.png)

--- a/docs/wire-tool-v1.0/user-manual/index.md
+++ b/docs/wire-tool-v1.0/user-manual/index.md
@@ -318,6 +318,7 @@ Requires:
 - 625RS Bearing
 - Pinch Bearing Boss
 - M4x16 Countersunk Screw (2)
+- M4x25 Buttonhead Cap Screw
 - Tension Spring
 - M3 Rivnut
 

--- a/docs/wire-tool-v1.0/user-manual/index.md
+++ b/docs/wire-tool-v1.0/user-manual/index.md
@@ -200,7 +200,6 @@ The following hardware is required for assembly of the WT-01:
 |M3 Rivnut                            |         1         |
 |135mm PTFE Tube                      |         1         |
 |Wago 221-412                         |         4         |
-|Wago 221-413                         |         1         |
 |M3x8 Buttonhead Cap Screw            |         6         |
 |M3x16 Countersunk Screw              |         1         |
 |M4x16 Countersunk Screw              |         11        |


### PR DESCRIPTION
1. The tensioner body assembly needs a M4x25 button head cap screw, but it's not called out. 
2. The tool mount assembly calls out a Wago 221-413, but it's never used.
