### PR TITLE
Workflow Bugfix: Use release tags to filter versions and avoid pagination

### DIFF
--- a/install-hugo.sh
+++ b/install-hugo.sh
@@ -13,15 +13,16 @@ fi
 VFILE=".hugoversion"
 VERSION=$(cat $VFILE)
 
-echo "Searching for Hugo $VERSION"
+TAG_URL="https://api.github.com/repos/gohugoio/hugo/releases/tags/$VERSION"
+echo "Searching for Hugo $VERSION at $TAG_URL"
 
-URL=`curl -s https://api.github.com/repos/gohugoio/hugo/releases \
-      | jq -r --arg version $VERSION \
-          '[.[] 
-          | select(.tag_name == $version) 
-          | .assets[] 
-          | select(.browser_download_url | test("hugo_extended(.*)Linux-64bit"))][0]
-          | .browser_download_url'`
+URL=$(curl -s "$TAG_URL" |
+    jq -r '[.assets[] | select(.browser_download_url | test("hugo_extended.*Linux-64bit"))][0] | .browser_download_url')
+
+if [[ -z "$URL" || "$URL" == "null" ]]; then
+  echo "Could not find a suitable Hugo binary for $VERSION."
+  exit 1
+fi
 
 echo "Found $URL"
 


### PR DESCRIPTION
## Update Hugo Installer Script to Use Tag-Specific GitHub API Endpoint

### Summary
This PR updates the install-hugo.sh script to reliably fetch and install the specified Hugo version by querying the GitHub API for a specific release tag, rather than relying on the paginated list of releases. This resolves issues where older releases (such as v0.127.0) were not found due to GitHub API pagination limits.

### Details
- The script now uses the endpoint:  
  `https://api.github.com/repos/gohugoio/hugo/releases/tags/$VERSION`
- This ensures the correct release is always found, regardless of the number of releases.
- The asset selection logic and error handling remain robust.
- The script will exit gracefully with a clear error message if the desired asset is not found.
